### PR TITLE
Consolidate and bump jetty artifacts version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
         <app.name>SaaS Functional Testing Framework</app.name>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+    <!--    Dependency versions    -->
+        <jetty.version>9.4.44.v20210927</jetty.version>
     </properties>
 
     <modules>
@@ -308,73 +310,73 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-client</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-continuation</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-http</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-io</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-proxy</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-security</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlets</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-util</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-webapp</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-xml</artifactId>
                 <type>jar</type>
-                <version>9.4.40.v20210413</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch</groupId>


### PR DESCRIPTION
Moved all jetty artifacts versions to a single maven property and
bumped the version according to Dependabot's security recomendations.