### PR TITLE
Remove *dpa* from names

### DIFF
--- a/test-autoconfig-lib/src/main/java/com/vmware/test/functional/saas/local/CustomDockerContainer.java
+++ b/test-autoconfig-lib/src/main/java/com/vmware/test/functional/saas/local/CustomDockerContainer.java
@@ -25,8 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class CustomDockerContainer extends GenericContainer<CustomDockerContainer> {
 
-    public static final Duration DEFAULT_DOCKER_CONTAINER_STARTUP_TIMEOUT = Duration.ofSeconds(240);
-    public static final Duration DEFAULT_WAIT_STRATEGY_TIMEOUT = Duration.ofSeconds(240);
+    public static final Duration DEFAULT_DOCKER_CONTAINER_STARTUP_TIMEOUT = Duration.ofSeconds(480);
+    public static final Duration DEFAULT_WAIT_STRATEGY_TIMEOUT = Duration.ofSeconds(480);
 
     CustomDockerContainer(final RemoteDockerImage image,
             final ServiceEndpoint serviceEndpoint) {

--- a/test-functional/src/main/java/com/vmware/test/functional/saas/FunctionalConfig.java
+++ b/test-functional/src/main/java/com/vmware/test/functional/saas/FunctionalConfig.java
@@ -12,8 +12,8 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
-import com.vmware.test.functional.saas.process.DpaTestApp;
-import com.vmware.test.functional.saas.process.DpaTestAppDebug;
+import com.vmware.test.functional.saas.process.TestAppSettings;
+import com.vmware.test.functional.saas.process.TestAppDebugSettings;
 import com.vmware.test.functional.saas.process.TestProcessGenericRunner;
 import com.vmware.test.functional.saas.process.TestProcessLifecycle;
 
@@ -38,13 +38,13 @@ public class FunctionalConfig {
     }
 
     @Bean
-    DpaTestApp defaultDpaTestApp() {
-        return new DpaTestApp();
+    TestAppSettings defaultTestAppSettings() {
+        return new TestAppSettings();
     }
 
     @Bean
-    DpaTestAppDebug defaultDpaTestAppDebug() {
-        return new DpaTestAppDebug();
+    TestAppDebugSettings defaultTestAppDebugSettings() {
+        return new TestAppDebugSettings();
     }
 
     @Bean

--- a/test-functional/src/main/java/com/vmware/test/functional/saas/InternalContainerServiceConfig.java
+++ b/test-functional/src/main/java/com/vmware/test/functional/saas/InternalContainerServiceConfig.java
@@ -17,7 +17,7 @@ import lombok.NonNull;
 @Getter
 public class InternalContainerServiceConfig {
 
-    private static final String NETWORK_NAME = "dpa_test_network_" + RandomUtils.nextInt();
+    private static final String NETWORK_NAME = "test_network_" + RandomUtils.nextInt();
 
     @NonNull
     private final String imageName;

--- a/test-functional/src/main/java/com/vmware/test/functional/saas/process/LocalAppProcessConfigTemplate.java
+++ b/test-functional/src/main/java/com/vmware/test/functional/saas/process/LocalAppProcessConfigTemplate.java
@@ -29,8 +29,8 @@ public final class LocalAppProcessConfigTemplate {
 
     private static final String AWS_CBOR_DISABLE_SYSTEM_PROPERTY = "com.amazonaws.sdk.disableCbor";
     private static final String DISABLE_CERT_CHECKING_SYSTEM_PROPERTY = "com.amazonaws.sdk.disableCertChecking";
-    private final DpaTestApp dpaTestApp;
-    private final DpaTestAppDebug dpaTestAppDebug;
+    private final TestAppSettings testAppSettings;
+    private final TestAppDebugSettings testAppDebugSettings;
     private final ServiceEndpoint appEndpoint;
     @Builder.Default
     private final List<String> additionalAppCommandLineArgs = List.of();
@@ -43,14 +43,14 @@ public final class LocalAppProcessConfigTemplate {
     public LocalTestProcessCtl.LocalTestProcessCtlBuilder defaultTestProcessBuilder() {
         return LocalTestProcessCtl.builder()
                 .command(() -> this.createAppCommand(this.additionalAppCommandLineArgs))
-                .debugModeEnable(this.dpaTestAppDebug.getDebugModeEnable())
-                .debugPort(this.dpaTestAppDebug.getDebugPort())
-                .debugSuspendMode(this.dpaTestAppDebug.getDebugSuspend())
+                .debugModeEnable(this.testAppDebugSettings.isDebugModeEnable())
+                .debugPort(this.testAppDebugSettings.getDebugPort())
+                .debugSuspendMode(this.testAppDebugSettings.getDebugSuspend())
                 .waitingFor(this.createDefaultAppHealthEndpointWaitStrategy(this.appEndpoint));
     }
 
     CommandLine createAppCommand(final List<String> commandLineArgs) {
-        if (StringUtils.isBlank(this.dpaTestApp.getExecutableJar())) {
+        if (StringUtils.isBlank(this.testAppSettings.getExecutableJar())) {
             throw new IllegalArgumentException("Executable JAR not configured - cannot be null/empty");
         }
 
@@ -73,7 +73,7 @@ public final class LocalAppProcessConfigTemplate {
         }
 
         // Lastly, add the required executable jar reference
-        commandLine.addArgument("-jar").addArgument(this.dpaTestApp.getExecutableJar());
+        commandLine.addArgument("-jar").addArgument(this.testAppSettings.getExecutableJar());
         log.debug("Using CommandLine: [{}]", commandLine);
 
         return commandLine;

--- a/test-functional/src/main/java/com/vmware/test/functional/saas/process/LocalTestProcessCtl.java
+++ b/test-functional/src/main/java/com/vmware/test/functional/saas/process/LocalTestProcessCtl.java
@@ -65,9 +65,9 @@ public final class LocalTestProcessCtl implements Lifecycle {
     @Getter(AccessLevel.PACKAGE)
     private final Supplier<Map<String, String>> environmentSupplier;
     @Getter(AccessLevel.PACKAGE)
-    private final String debugModeEnable;
+    private final boolean debugModeEnable;
     @Getter(AccessLevel.PACKAGE)
-    private final String debugPort;
+    private final int debugPort;
     @Getter(AccessLevel.PACKAGE)
     private final String debugSuspendMode;
     private final Environment environment;
@@ -242,8 +242,7 @@ public final class LocalTestProcessCtl implements Lifecycle {
 
     private CommandLine setDebugArguments() {
         final CommandLine cmd = new CommandLine(this.command.get().getExecutable());
-        if (Boolean.parseBoolean(this.debugModeEnable)
-                && StringUtils.isNotBlank(this.debugPort)) {
+        if (this.isDebugModeEnable()) {
             final String suspendMode = StringUtils.equals(this.debugSuspendMode, "y") ? this.debugSuspendMode : "n";
             final String[] arguments = {
                     "-Xdebug",

--- a/test-functional/src/main/java/com/vmware/test/functional/saas/process/TestAppDebugSettings.java
+++ b/test-functional/src/main/java/com/vmware/test/functional/saas/process/TestAppDebugSettings.java
@@ -13,17 +13,17 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Test application configuration properties.
+ * Debug options for a test application.
  */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Qualifier("dpaTestApp")
-public class DpaTestApp {
+@Qualifier("testAppDebugSettings")
+public class TestAppDebugSettings {
 
-    @Value("${app.apphome}")
-    private String apphome;
+    private boolean debugModeEnable = false;
 
-    @Value("${app.executable.jar}")
-    private String executableJar;
+    private int debugPort = 8998;
+
+    private String debugSuspend = "n";
 }

--- a/test-functional/src/main/java/com/vmware/test/functional/saas/process/TestAppSettings.java
+++ b/test-functional/src/main/java/com/vmware/test/functional/saas/process/TestAppSettings.java
@@ -13,20 +13,15 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Debug options for a test application.
+ * Test application configuration properties.
  */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Qualifier("dpaTestAppDebug")
-public class DpaTestAppDebug {
+@Qualifier("testAppSettings")
+public class TestAppSettings {
 
-    @Value("${dpa.test.app.debug.mode.enable:false}")
-    private String debugModeEnable;
+    private String apphome;
 
-    @Value("${dpa.test.app.debug.port:8998}")
-    private String debugPort;
-
-    @Value("${dpa.test.app.debug.suspend:n}")
-    private String debugSuspend;
+    private String executableJar;
 }

--- a/test-functional/src/test/java/com/vmware/test/functional/saas/process/LocalAppProcessConfigTemplateTest.java
+++ b/test-functional/src/test/java/com/vmware/test/functional/saas/process/LocalAppProcessConfigTemplateTest.java
@@ -30,7 +30,6 @@ import static org.hamcrest.Matchers.*;
 @TestPropertySource(properties = {
         "pizza.executableJar=my-pizza.jar",
         "pizza.apphome=/spaghetti",
-        "dpa.test.app.debug.mode.enable=false",
         "pizza.debug.debugModeEnable=true"})
 public class LocalAppProcessConfigTemplateTest extends AbstractTestNGSpringContextTests {
 
@@ -40,14 +39,14 @@ public class LocalAppProcessConfigTemplateTest extends AbstractTestNGSpringConte
 
         @Bean
         @ConfigurationProperties(prefix = "pizza")
-        DpaTestApp dpaTestPizzaApp() {
-            return new DpaTestApp();
+        TestAppSettings testPizzaAppSettings() {
+            return new TestAppSettings();
         }
 
         @Bean
         @ConfigurationProperties(prefix = "pizza.debug")
-        DpaTestAppDebug dpaTestPizzaAppDebug() {
-            return new DpaTestAppDebug();
+        TestAppDebugSettings testPizzaAppDebugSettings() {
+            return new TestAppDebugSettings();
         }
 
         @Bean
@@ -60,11 +59,11 @@ public class LocalAppProcessConfigTemplateTest extends AbstractTestNGSpringConte
         public LocalTestProcessCtl pizzaAppProcess() {
             final LocalAppProcessConfigTemplate template = LocalAppProcessConfigTemplate
                     .builder().appEndpoint(pizzaAppEndpoint())
-                    .dpaTestApp(dpaTestPizzaApp())
-                    .dpaTestAppDebug(dpaTestPizzaAppDebug())
+                    .testAppSettings(testPizzaAppSettings())
+                    .testAppDebugSettings(testPizzaAppDebugSettings())
                     .build();
             return template.defaultTestProcessBuilder()
-                    .environmentSupplier(() -> Map.of("APP_HOME", dpaTestPizzaApp().getApphome()))
+                    .environmentSupplier(() -> Map.of("APP_HOME", testPizzaAppSettings().getApphome()))
                     .build();
         }
     }
@@ -74,8 +73,8 @@ public class LocalAppProcessConfigTemplateTest extends AbstractTestNGSpringConte
 
     @Test
     public void ensureDebugEnabledIsCorrect() {
-        final String debugEnabled = this.pizzaAppProcess.getDebugModeEnable();
-        assertThat("debug enabled", debugEnabled, is("true"));
+        final boolean debugEnabled = this.pizzaAppProcess.isDebugModeEnable();
+        assertThat("debug enabled", debugEnabled, is(true));
     }
 
     @Test

--- a/test-local-autoconfig/src/main/java/com/vmware/test/functional/saas/local/aws/lambda/sam/SamAutoConfiguration.java
+++ b/test-local-autoconfig/src/main/java/com/vmware/test/functional/saas/local/aws/lambda/sam/SamAutoConfiguration.java
@@ -14,13 +14,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.vmware.test.functional.saas.ConditionalOnService;
 import com.vmware.test.functional.saas.FunctionalTestExecutionSettings;
 import com.vmware.test.functional.saas.ServiceEndpoint;
 import com.vmware.test.functional.saas.Service;
-import com.vmware.test.functional.saas.local.aws.lambda.sam.process.SamProcessControl;
 import com.vmware.test.functional.saas.aws.lambda.LambdaFunctionSpecs;
-import com.vmware.test.functional.saas.ConditionalOnService;
-import com.vmware.test.functional.saas.process.DpaTestAppDebug;
+import com.vmware.test.functional.saas.local.aws.lambda.sam.process.SamProcessControl;
+import com.vmware.test.functional.saas.process.TestAppDebugSettings;
 
 /**
  * Sam Process Autoconfiguration.
@@ -42,13 +42,13 @@ public class SamAutoConfiguration {
      * Note: In the above case, we should also ensure that all autowire points in the app are qualified
      * (e.g. @Qualifier or by parameter name) so that no DuplicateBeanDefinitionException for these instances.
      *
-     * @return {@code DpaTestAppDebug} bean.
+     * @return {@code TestAppDebugSettings} bean.
      */
     @Bean
     @ConfigurationProperties(prefix = "default.test.lambda")
     @ConditionalOnService(value = Service.LAMBDA)
-    DpaTestAppDebug dpaTestAppDebug() {
-        return new DpaTestAppDebug();
+    TestAppDebugSettings testAppDebug() {
+        return new TestAppDebugSettings();
     }
 
     @Bean
@@ -60,8 +60,8 @@ public class SamAutoConfiguration {
         return SamProcessControl.builder()
                 .lambdaEndpoint(lambdaEndpoint)
                 .lambdaFunctionSpecs(lambdaFunctionSpecs)
-                .debugPort(dpaTestAppDebug().getDebugPort())
-                .debugModeEnabled(Boolean.parseBoolean(dpaTestAppDebug().getDebugModeEnable()))
+                .debugPort(testAppDebug().getDebugPort())
+                .debugModeEnabled(testAppDebug().isDebugModeEnable())
                 .functionalTestExecutionSettings(functionalTestExecutionSettings)
                 .additionalCommandLineArgs(this.additionalCommandLineArgs)
                 .build();

--- a/test-local-autoconfig/src/main/java/com/vmware/test/functional/saas/local/aws/lambda/sam/process/SamProcessControl.java
+++ b/test-local-autoconfig/src/main/java/com/vmware/test/functional/saas/local/aws/lambda/sam/process/SamProcessControl.java
@@ -76,7 +76,7 @@ public class SamProcessControl implements SmartLifecycle {
     private final ServiceEndpoint lambdaEndpoint;
     private final List<LambdaFunctionSpecs> lambdaFunctionSpecs;
     private final boolean debugModeEnabled;
-    private final String debugPort;
+    private final int debugPort;
     private final String[] additionalCommandLineArgs;
     private final FunctionalTestExecutionSettings functionalTestExecutionSettings;
 
@@ -95,7 +95,7 @@ public class SamProcessControl implements SmartLifecycle {
     public SamProcessControl(@NonNull final ServiceEndpoint lambdaEndpoint,
             @NonNull final List<LambdaFunctionSpecs> lambdaFunctionSpecs,
             final boolean debugModeEnabled,
-            final String debugPort,
+            final int debugPort,
             final String[] additionalCommandLineArgs,
             final FunctionalTestExecutionSettings functionalTestExecutionSettings) {
         this.lambdaEndpoint = lambdaEndpoint;
@@ -301,7 +301,7 @@ public class SamProcessControl implements SmartLifecycle {
         this.cmd.addArguments(new String[] { "--log-file", this.lambdaLogFile });
 
         if (this.debugModeEnabled) {
-            this.cmd.addArguments(new String[] { "-d", this.debugPort });
+            this.cmd.addArguments(new String[] { "-d", String.valueOf(this.debugPort) });
             this.cmd.addArgument("--debug");
         }
     }

--- a/test-local-autoconfig/src/test/java/com/vmware/test/functional/saas/local/aws/redshift/RedshiftTest.java
+++ b/test-local-autoconfig/src/test/java/com/vmware/test/functional/saas/local/aws/redshift/RedshiftTest.java
@@ -67,7 +67,7 @@ public class RedshiftTest extends AbstractFullContextTest {
 
     @BeforeClass(alwaysRun = true)
     public void createTable() {
-        this.testTable = "test_dpa";
+        this.testTable = "test_table";
         this.testColumn = "test_id";
         final String createTableCmd = String.format("CREATE TABLE %s (%s VARCHAR(256) NOT NULL)",
                 this.testTable, this.testColumn);


### PR DESCRIPTION
Rename
- DpaTestApp->TestAppSettings
- DpaTestAppDebug->TestAppDebugSettings
- dpa_test_network_*-> test_network_*
- test_dpa->test_table

change debugModeEnable type to boolean and debugPort type to int

remove @Value("${dpa.test.app.debug.***}") and @Value("${app.**}"). These are no needed since we move away from global configuration names and prefer configuration names that have a namespace suffix