### PR TITLE
Address a security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,15 @@
 
     <properties>
         <app.name>SaaS Functional Testing Framework</app.name>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <!-- Skip GPG signing by default -->
         <gpg.skip>true</gpg.skip>
         <!--    Dependency versions    -->
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jetty.version>11.0.15</jetty.version>
+        <spring.version>6.0.11</spring.version>
+        <spring-boot.version>3.1.2</spring-boot.version>
+        <logback.version>1.4.8</logback.version>
     </properties>
 
     <modules>
@@ -73,13 +76,13 @@
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <type>jar</type>
-                <version>1.2.10</version>
+                <version>${logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
                 <type>jar</type>
-                <version>1.2.10</version>
+                <version>${logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
@@ -139,7 +142,7 @@
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock</artifactId>
                 <type>jar</type>
-                <version>2.27.2</version>
+                <version>3.0.0-beta-10</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -469,41 +472,41 @@
                 <type>jar</type>
                 <version>1.18.22</version>
             </dependency>
+            <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <type>jar</type>
-                <version>1.7.36</version>
+                <version>2.0.7</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-jcl</artifactId>
                 <type>jar</type>
-                <version>5.3.18</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-autoconfigure</artifactId>
                 <type>jar</type>
-                <version>2.5.15</version>
+                <version>${spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-test-autoconfigure</artifactId>
                 <type>jar</type>
-                <version>2.5.9</version>
+                <version>${spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-test</artifactId>
                 <type>jar</type>
-                <version>2.5.9</version>
+                <version>${spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-contract-wiremock</artifactId>
                 <type>jar</type>
-                <version>3.0.2</version>
+                <version>4.0.4</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.data</groupId>
@@ -515,31 +518,31 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-beans</artifactId>
                 <type>jar</type>
-                <version>5.3.18</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
                 <type>jar</type>
-                <version>5.3.15</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-jdbc</artifactId>
                 <type>jar</type>
-                <version>5.3.15</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-test</artifactId>
                 <type>jar</type>
-                <version>5.3.15</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
                 <type>jar</type>
-                <version>5.3.15</version>
+                <version>${spring.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>

--- a/test-aws-lambda-logback/pom.xml
+++ b/test-aws-lambda-logback/pom.xml
@@ -15,11 +15,13 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <version>1.2.10</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
+            <version>1.2.10</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -30,6 +32,16 @@
     </dependencies>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <reporting>

--- a/test-functional-sdk/pom.xml
+++ b/test-functional-sdk/pom.xml
@@ -134,12 +134,6 @@
         </dependency>
         <dependency>
             <groupId>com.vmware.saas.functional.test</groupId>
-            <artifactId>simple-lambda</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.vmware.saas.functional.test</groupId>
             <artifactId>test-testng</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/test-functional/pom.xml
+++ b/test-functional/pom.xml
@@ -82,6 +82,11 @@
         <!-- Provided scope dependencies  -->
         <!-- ============================ -->
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/test-functional/src/main/resources/META-INF/spring.factories
+++ b/test-functional/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,3 @@
-com.vmware.test.functional.saas.FunctionalTest=com.vmware.test.functional.saas.FunctionalConfig
 org.springframework.test.context.TestExecutionListener=\
   com.vmware.test.functional.saas.FunctionalTestExecutionListener,\
   com.vmware.test.functional.saas.TestClassScopeExecutionListener

--- a/test-functional/src/main/resources/META-INF/spring/com.vmware.test.functional.saas.FunctionalTest.imports
+++ b/test-functional/src/main/resources/META-INF/spring/com.vmware.test.functional.saas.FunctionalTest.imports
@@ -1,0 +1,1 @@
+com.vmware.test.functional.saas.FunctionalConfig

--- a/test-functional/src/test/java/com/vmware/test/functional/saas/environment/CalculateEnvironmentUtilsTest.java
+++ b/test-functional/src/test/java/com/vmware/test/functional/saas/environment/CalculateEnvironmentUtilsTest.java
@@ -10,10 +10,14 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
+import com.vmware.test.functional.saas.FunctionalTest;
+import com.vmware.test.functional.saas.SharedConfig;
 import com.vmware.test.functional.saas.process.LocalTestProcessCtl;
 import com.vmware.test.functional.saas.process.TestApp;
 import com.vmware.test.functional.saas.process.TestCommand;
@@ -25,6 +29,8 @@ import static org.hamcrest.MatcherAssert.*;
  * Tests to verify how {@link LocalTestProcessCtl} environment is calculated.
  */
 @TestPropertySource(properties = { "prefix.app.env.var1=newValue1", "app.env.var2=newValue2" })
+@ContextHierarchy(@ContextConfiguration(classes = SharedConfig.class))
+@FunctionalTest
 public class CalculateEnvironmentUtilsTest extends AbstractTestNGSpringContextTests {
 
     private static final String TEST_EVN_VAR_1_VALUE = "value1";

--- a/test-functional/src/test/java/com/vmware/test/functional/saas/process/HttpWaitStrategyTest.java
+++ b/test-functional/src/test/java/com/vmware/test/functional/saas/process/HttpWaitStrategyTest.java
@@ -8,7 +8,7 @@ package com.vmware.test.functional.saas.process;
 import java.time.Duration;
 
 import org.apache.commons.exec.CommandLine;
-import org.apache.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;

--- a/test-functional/src/test/resources/META-INF/spring.factories
+++ b/test-functional/src/test/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-com.vmware.test.functional.saas.SharedConfig=com.vmware.test.functional.saas.scope.context.TestClassScopeParentContext

--- a/test-functional/src/test/resources/META-INF/spring/com.vmware.test.functional.saas.SharedConfig.imports
+++ b/test-functional/src/test/resources/META-INF/spring/com.vmware.test.functional.saas.SharedConfig.imports
@@ -1,0 +1,1 @@
+com.vmware.test.functional.saas.scope.context.TestClassScopeParentContext

--- a/test-local-autoconfig/pom.xml
+++ b/test-local-autoconfig/pom.xml
@@ -71,7 +71,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test-autoconfigure</artifactId>
-            <version>2.5.11</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/test-local-autoconfig/src/main/resources/META-INF/spring.factories
+++ b/test-local-autoconfig/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,1 @@
-com.vmware.test.functional.saas.FunctionalTest=com.vmware.test.functional.saas.local.config.LocalServicesXmlConfiguration,\
-  com.vmware.test.functional.saas.local.aws.config.LocalAwsServicesAutoConfiguration,\
-  com.vmware.test.functional.saas.local.config.LocalServicesAutoConfiguration,\
-  com.vmware.test.functional.saas.local.LocalstackContainerConfig,\
-  com.vmware.test.functional.saas.local.aws.lambda.sam.SamAutoConfiguration
 org.springframework.boot.SpringApplicationRunListener=com.vmware.test.functional.saas.local.aws.config.ErrorLoggingSpringApplicationRunListener

--- a/test-local-autoconfig/src/main/resources/META-INF/spring/com.vmware.test.functional.saas.FunctionalTest.imports
+++ b/test-local-autoconfig/src/main/resources/META-INF/spring/com.vmware.test.functional.saas.FunctionalTest.imports
@@ -1,0 +1,5 @@
+com.vmware.test.functional.saas.local.config.LocalServicesXmlConfiguration
+com.vmware.test.functional.saas.local.aws.config.LocalAwsServicesAutoConfiguration
+com.vmware.test.functional.saas.local.config.LocalServicesAutoConfiguration
+com.vmware.test.functional.saas.local.LocalstackContainerConfig
+com.vmware.test.functional.saas.local.aws.lambda.sam.SamAutoConfiguration

--- a/test-local-autoconfig/src/test/java/com/vmware/test/functional/saas/local/aws/lambda/sam/process/SamProcessControlHelperTest.java
+++ b/test-local-autoconfig/src/test/java/com/vmware/test/functional/saas/local/aws/lambda/sam/process/SamProcessControlHelperTest.java
@@ -5,15 +5,21 @@
 
 package com.vmware.test.functional.saas.local.aws.lambda.sam.process;
 
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
+import com.vmware.test.functional.saas.FunctionalTest;
+
 /**
  * Tests for {@link SamProcessControlHelper}.
  */
+@FunctionalTest
+@ContextHierarchy(@ContextConfiguration(classes = SamProcessControlHelperTest.LocalConfig.class))
 public class SamProcessControlHelperTest extends AbstractTestNGSpringContextTests {
 
     @Test
@@ -39,5 +45,7 @@ public class SamProcessControlHelperTest extends AbstractTestNGSpringContextTest
         } catch (final RuntimeException ex) {
             assertThat(ex.getMessage(), equalTo(String.format(SamProcessControlHelper.OUTPUT_MISMATCH_MESSAGE_FORMAT, wrongVersion)));
         }
+    }
+    static class LocalConfig {
     }
 }

--- a/test-local-autoconfig/src/test/java/com/vmware/test/functional/saas/local/aws/lambda/sam/process/SamProcessControlInvalidStartTest.java
+++ b/test-local-autoconfig/src/test/java/com/vmware/test/functional/saas/local/aws/lambda/sam/process/SamProcessControlInvalidStartTest.java
@@ -8,10 +8,13 @@ package com.vmware.test.functional.saas.local.aws.lambda.sam.process;
 import java.util.Collections;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import com.vmware.test.functional.saas.FunctionalTest;
 import com.vmware.test.functional.saas.ServiceEndpoint;
 import com.vmware.test.functional.saas.PortSupplier;
 import com.vmware.test.functional.saas.local.aws.lambda.constants.TestConstants;
@@ -22,6 +25,8 @@ import static org.hamcrest.MatcherAssert.*;
 /**
  * Tests for {@link SamProcessControl}.
  */
+@FunctionalTest
+@ContextHierarchy(@ContextConfiguration(classes = SamProcessControlInvalidStartTest.LocalConfig.class))
 public class SamProcessControlInvalidStartTest extends AbstractTestNGSpringContextTests {
 
     @Value("${lambda.code.uri}")
@@ -63,5 +68,8 @@ public class SamProcessControlInvalidStartTest extends AbstractTestNGSpringConte
     @AfterMethod(alwaysRun = true)
     public void stopSamProcess() {
         this.samProcessControl.stop();
+    }
+
+    static class LocalConfig {
     }
 }

--- a/test-local-autoconfig/src/test/java/com/vmware/test/functional/saas/local/aws/lambda/sam/process/SamProcessControlTest.java
+++ b/test-local-autoconfig/src/test/java/com/vmware/test/functional/saas/local/aws/lambda/sam/process/SamProcessControlTest.java
@@ -12,9 +12,12 @@ import java.util.Collections;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
+import com.vmware.test.functional.saas.FunctionalTest;
 import com.vmware.test.functional.saas.ServiceEndpoint;
 import com.vmware.test.functional.saas.local.aws.lambda.constants.TestConstants;
 import com.vmware.test.functional.saas.aws.lambda.LambdaFunctionSpecs;
@@ -24,6 +27,8 @@ import static org.hamcrest.MatcherAssert.*;
 /**
  * Tests for {@link SamProcessControl}.
  */
+@FunctionalTest
+@ContextHierarchy(@ContextConfiguration(classes = SamProcessControlTest.LocalConfig.class))
 public class SamProcessControlTest extends AbstractTestNGSpringContextTests {
 
     @Value("${lambda.code.uri}")
@@ -258,5 +263,8 @@ public class SamProcessControlTest extends AbstractTestNGSpringContextTests {
         }
         assertThat("SamProcessControl: has started", !samProcessControl.isRunning());
         samProcessControl.stop();
+    }
+
+    static class LocalConfig {
     }
 }

--- a/test-local-autoconfig/src/test/resources/META-INF/spring.factories
+++ b/test-local-autoconfig/src/test/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-com.vmware.test.functional.saas.SharedConfig=com.vmware.test.functional.saas.local.context.TestContext$StartKmsServiceContext

--- a/test-local-autoconfig/src/test/resources/META-INF/spring/com.vmware.test.functional.saas.SharedConfig.imports
+++ b/test-local-autoconfig/src/test/resources/META-INF/spring/com.vmware.test.functional.saas.SharedConfig.imports
@@ -1,0 +1,1 @@
+com.vmware.test.functional.saas.local.context.TestContext$StartKmsServiceContext

--- a/test-samples/simple-lambda/pom.xml
+++ b/test-samples/simple-lambda/pom.xml
@@ -24,6 +24,25 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+            <scope>compile</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-lambda-java-core -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.10</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.2.10</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -52,6 +71,14 @@
                 <artifactId>duplicate-finder-maven-plugin</artifactId>
                 <configuration>
                     <checkTestClasspath>false</checkTestClasspath>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <release>11</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/test-wiremock/pom.xml
+++ b/test-wiremock/pom.xml
@@ -39,16 +39,20 @@
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
-                    <artifactId>jakarta.annotation-api</artifactId>
-                    <groupId>jakarta.annotation</groupId>
-                </exclusion>
-                <exclusion>
                     <artifactId>jul-to-slf4j</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.github.tomakehurst</groupId>
                     <artifactId>wiremock-jre8-standalone</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.servlet</groupId>
+                    <artifactId>jakarta.servlet-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -84,11 +88,11 @@
         <!-- ============================ -->
         <!-- Provided scope dependencies -->
         <!-- ============================ -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>javax.servlet</groupId>-->
+<!--            <artifactId>javax.servlet-api</artifactId>-->
+<!--            <scope>provided</scope>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/test-wiremock/src/main/resources/META-INF/spring.factories
+++ b/test-wiremock/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-com.vmware.test.functional.saas.FunctionalTest=com.vmware.test.functional.saas.wiremock.WireMockAutoConfiguration

--- a/test-wiremock/src/main/resources/META-INF/spring/com.vmware.test.functional.saas.FunctionalTest.imports
+++ b/test-wiremock/src/main/resources/META-INF/spring/com.vmware.test.functional.saas.FunctionalTest.imports
@@ -1,0 +1,1 @@
+com.vmware.test.functional.saas.wiremock.WireMockAutoConfiguration

--- a/test-wiremock/src/test/java/com/vmware/test/functional/saas/wiremock/WireMockAutoConfigurationTest.java
+++ b/test-wiremock/src/test/java/com/vmware/test/functional/saas/wiremock/WireMockAutoConfigurationTest.java
@@ -7,18 +7,21 @@ package com.vmware.test.functional.saas.wiremock;
 
 import java.io.IOException;
 
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpEntity;
+
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
+import com.vmware.test.functional.saas.FunctionalTest;
 import com.vmware.test.functional.saas.ServiceEndpoint;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -31,14 +34,14 @@ import static org.hamcrest.MatcherAssert.*;
  * Test for {@link WireMockAutoConfiguration}.
  */
 @ContextConfiguration(classes = WireMockAutoConfiguration.class)
-@Test
+@FunctionalTest
 public class WireMockAutoConfigurationTest extends AbstractTestNGSpringContextTests {
 
     @Autowired
     ServiceEndpoint wireMockEndpoint;
 
     @Test
-    public void startWireMockServer() throws IOException {
+    public void startWireMockServer() throws IOException, ParseException {
         createStubs();
 
         final int port = this.wireMockEndpoint.getPort();
@@ -48,9 +51,9 @@ public class WireMockAutoConfigurationTest extends AbstractTestNGSpringContextTe
 
         //Create a web request to localhost:port/api/test and expect ok with body = "tes
         try (CloseableHttpClient httpClient = HttpClients.createDefault();
-                CloseableHttpResponse response = httpClient.execute(request)) {
+             CloseableHttpResponse response = httpClient.execute(request)) {
 
-            assertThat("Expected HTTP.OK", response.getStatusLine().getStatusCode() == HttpStatus.OK.value());
+            assertThat("Expected HTTP.OK", response.getCode() == HttpStatus.OK.value());
 
             final HttpEntity entity = response.getEntity();
             assertThat("Expected response entity", entity != null);


### PR DESCRIPTION
* Bump the versions of spring, jetty and wiremock to latest
* Bump logback and slf4j for the framework code, but keep it 1.2.10 and 1.7.36 for the lambdas since SAM doesnt support Java 17 yet

Note:
- Spring6 moved the definitions for "ImportAutoConfig" annotated classes from spring.factories to spring/<class name>.imports
- eclipse jetty requires apache client5